### PR TITLE
Logging errors now logs errors instead of info

### DIFF
--- a/src/main/java/com/revature/rms/core/aspects/CoreLoggingAspect.java
+++ b/src/main/java/com/revature/rms/core/aspects/CoreLoggingAspect.java
@@ -38,7 +38,7 @@ public abstract class CoreLoggingAspect {
 	@AfterThrowing(pointcut = "logAll()", throwing = "e")
 	public void errorOccurrence(JoinPoint jp, Exception e){
 		String methodSig = extractMethodSignature(jp);
-		LOGGER.info(e + "was thrown in method " + methodSig + " at " + LocalDateTime.now());
+		LOGGER.error(e + "was thrown in method " + methodSig + " at " + LocalDateTime.now(), e);
 	}
 
 	public String extractMethodSignature(JoinPoint jp){


### PR DESCRIPTION
CODE FREEZE IN EFFECT, LET NEXT GROUP HANDLE THIS.
Modifies rms-core logging aspect to correctly log errors as errors instead of logging errors as info.